### PR TITLE
Adding the Requirement for Exporters to Export Proper Block State

### DIFF
--- a/README-NEXT.md
+++ b/README-NEXT.md
@@ -3,7 +3,7 @@
 > [!IMPORTANT]
 > This is the draft standard for CommonMCOBJ V2, to be released on March 23rd, 2025
 
-CommonMCOBJ is a spec to allow Minecraft OBJ exporters to provide extra metadata about the source world and OBJ (that would otherwise be lost) in a standard way.
+CommonMCOBJ is a spec to allow exported Minecraft OBJs to be closer their in-game counterparts, by creating a common standard for OBJs and creating extra metadata for details that would otherwise be lost.
 
 Table of Contents
 =================
@@ -55,6 +55,9 @@ To address these problems, the CommonMCOBJ spec defines a set of conventions for
 The following defines the spec for CommonMCOBJ Version 1. Unless marked otherwise, everything in defined is a requirement for exporters implementing CommonMCOBJ.
 
 For reference, see [cmc2OBJ](https://github.com/CommonMCOBJ/cmc2obj), which acts as the reference implementation of CommonMCOBJ.
+
+## Block States
+OBJ exporters following the CommonMCOBJ spec shall export the proper block state for <ins>all blocks</ins>. If an option to only check a pre-determined list of blocks for states exists to speed up exports, it shall <ins>not be enabled by default</ins>.
 
 ## Common Header
 _Credit to the OBJ header from Mineways (by Eric Haines), which has been used as reference for the CommonMCOBJ header_


### PR DESCRIPTION
(Quoting from #4)

> One area where there seems to be a discrepancy between in-game and exported OBJs is with block states. [Minecraft allows editing blocks state](https://minecraft.wiki/w/Debug_Stick) in-game for creativity purposes. Some examples include:
> - Preventing blocks such as walls, fences, and glass panes from being chained
> -  Allowing blocks to float that normally wouldn't be allowed (take levers for instance)
> - Etc.
> 
> Although CommonMCOBJ states as a [non-goal](https://github.com/CommonMCOBJ/CommonMCOBJ#non-goals) 
> > - Governing every behavior in Minecraft OBJ exporters; that would be hard to adopt and stifle experimentation,
> 
> I think an exception can be made here as it's a vanilla game feature with legitimate use, and expands creative opportunities for artists. Granted, it may cause exports to be slower, but ultimately, exports shouldn't look different from how they look in game.
> 
> As such, I propose we add the following section to CommonMCOBJ for V2 of the spec (2025):
> > ## Block States
> > OBJ exporters following the CommonMCOBJ spec shall export the proper block state for <ins>all blocks</ins>. If an option to only check a pre-determined list of blocks for states exists to speed up exports, it shall <ins>not be enabled by default</ins>.
> 
> EDIT 01/04/2024: if wanted, we could change the description of CommonMCOBJ to the following in V2:
> > CommonMCOBJ is a spec to allow exported Minecraft OBJs to be closer their in-game counterparts, by creating a common standard for OBJs and creating extra metadata for details that would otherwise be lost. 